### PR TITLE
Revert "Enabling the ability to create but not overwrite config file"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,8 +25,6 @@
 # @param commitlog_directory_mode [string]  The mode for the
 #   `commitlog_directory` is ignored unless `commitlog_directory` is
 #   specified.
-# @param manage_config_file [boolean] Whether or not to manage the cassandra configuration
-#   file.
 # @param config_file_mode [string] The permissions mode of the cassandra configuration
 #   file.
 # @param config_path [string] The path to the cassandra configuration file.
@@ -134,7 +132,6 @@ class cassandra (
   $cassandra_yaml_tmpl          = 'cassandra/cassandra.yaml.erb',
   $commitlog_directory          = undef,
   $commitlog_directory_mode     = '0750',
-  Boolean $manage_config_file   = true,
   $config_file_mode             = '0644',
   $config_path                  = $::cassandra::params::config_path,
   $data_file_directories        = undef,
@@ -258,14 +255,12 @@ class cassandra (
     refreshonly => true,
   }
 
-  if $manage_config_file {
-    file { $config_path:
-      ensure  => directory,
-      group   => 'cassandra',
-      owner   => 'cassandra',
-      mode    => '0755',
-      require => $config_path_require,
-    }
+  file { $config_path:
+    ensure  => directory,
+    group   => 'cassandra',
+    owner   => 'cassandra',
+    mode    => '0755',
+    require => $config_path_require,
   }
 
   if $commitlog_directory {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -55,7 +55,6 @@ describe 'cassandra' do
         cassandra_9822: false,
         cassandra_yaml_tmpl: 'cassandra/cassandra.yaml.erb',
         commitlog_directory_mode: '0750',
-        manage_config_file: true,
         config_file_mode: '0644',
         config_path: '/etc/cassandra/default.conf',
         data_file_directories_mode: '0750',


### PR DESCRIPTION
Reverts change made in 95746bce47d885b009fba60d76f59618438b41d3.

I am not using it for the time being.

The cassandra package install seems to put a file their anyways, with root as owner. So I'd still need to have my own code to change the owner of that file (either a chown exec, or a replace => false, precisely against [this suggestion](https://github.com/voxpupuli/puppet-cassandra/pull/409#issuecomment-341384070)). Further, while Priam manages some properties of the config file, it struggles to manage anything other than simple strings. While I do believe a more dynamic yaml modification mechanism in Priam would be the correct solution, I'm opting to use puppet-cassandra for now to put the file into an initial state, and Priam to add a few tweaks based on more complex logic. 

This also doesn't work right now. https://github.com/voxpupuli/puppet-cassandra/pull/417 filed for alternative fix instead of removal