### PR TITLE
Add SCL support to cassandra::schema

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,6 +50,8 @@ class cassandra::params {
       $jna_package_name = 'jna'
       $optutils_package_name = 'cassandra22-tools'
       $systemctl = '/usr/bin/systemctl'
+      $use_scl = false
+      $scl_name = 'nodefault'
     }
     default: {
       $config_path_parents = []

--- a/manifests/schema.pp
+++ b/manifests/schema.pp
@@ -49,8 +49,8 @@ class cassandra::schema (
   $permissions              = {},
   $tables                   = {},
   $users                    = {},
-  $use_scl                  = $::cassandra::params::use_scl,
-  $scl_name                 = $::cassandra::params::scl_name,
+  $use_scl                  = $cassandra::params::use_scl,
+  $scl_name                 = $cassandra::params::scl_name,
   ) inherits cassandra::params {
   require '::cassandra'
 

--- a/manifests/schema.pp
+++ b/manifests/schema.pp
@@ -95,7 +95,13 @@ class cassandra::schema (
 
   # See if we can make a connection to Cassandra.  Try $connection_tries
   # number of times with $connection_try_sleep in seconds between each try.
-  $connection_test = "${cqlsh_opts} -e 'DESC KEYSPACES' ${cqlsh_conn}"
+  $connection_test_tmp = "${cqlsh_opts} -e 'DESC KEYSPACES' ${cqlsh_conn}"
+  if $use_scl {
+    $connection_test = "/usr/bin/scl enable ${scl_name} \"${connection_test_tmp}\""
+  } else {
+    $connection_test = $connection_test_tmp
+  }
+
   exec { '::cassandra::schema connection test':
     command   => $connection_test,
     returns   => 0,

--- a/manifests/schema.pp
+++ b/manifests/schema.pp
@@ -54,16 +54,6 @@ class cassandra::schema (
   ) inherits cassandra::params {
   require '::cassandra'
 
-  # Test that the SCL is valid
-  if $use_scl {
-    exec { "test ${scl_name} SCL":
-      command => "/usr/bin/scl enable ${scl_name} \"echo test\"",
-    }
-    $scl_require = Exec["test ${scl_name} SCL"]
-  } else {
-    $scl_require = undef
-  }
-
   # Pass the SCL info to create_resources below as a hash
   $scl = {
     'use_scl'  => $use_scl,
@@ -108,7 +98,6 @@ class cassandra::schema (
     tries     => $connection_tries,
     try_sleep => $connection_try_sleep,
     unless    => $connection_test,
-    require   => $scl_require,
   }
 
   # manage keyspaces if present

--- a/manifests/schema.pp
+++ b/manifests/schema.pp
@@ -49,8 +49,8 @@ class cassandra::schema (
   $permissions              = {},
   $tables                   = {},
   $users                    = {},
-  $use_scl                  = $cassandra::params::use_scl,
-  $scl_name                 = $cassandra::params::scl_name,
+  Boolean $use_scl          = $cassandra::params::use_scl,
+  String[1] $scl_name       = $cassandra::params::scl_name,
   ) inherits cassandra::params {
   require '::cassandra'
 

--- a/manifests/schema/cql_type.pp
+++ b/manifests/schema/cql_type.pp
@@ -16,6 +16,8 @@ define cassandra::schema::cql_type (
   $ensure = present,
   $fields = {},
   $cql_type_name = $title,
+  $use_scl       = $::cassandra::params::use_scl,
+  $scl_name      = $::cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
   $read_script = "DESC TYPE ${keyspace}.${cql_type_name}"

--- a/manifests/schema/cql_type.pp
+++ b/manifests/schema/cql_type.pp
@@ -16,8 +16,8 @@ define cassandra::schema::cql_type (
   $ensure = present,
   $fields = {},
   $cql_type_name = $title,
-  $use_scl       = $cassandra::params::use_scl,
-  $scl_name      = $cassandra::params::scl_name,
+  Boolean $use_scl = $cassandra::params::use_scl,
+  String[1] $scl_name = $cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/cql_type.pp
+++ b/manifests/schema/cql_type.pp
@@ -16,8 +16,8 @@ define cassandra::schema::cql_type (
   $ensure = present,
   $fields = {},
   $cql_type_name = $title,
-  $use_scl       = $::cassandra::params::use_scl,
-  $scl_name      = $::cassandra::params::scl_name,
+  $use_scl       = $cassandra::params::use_scl,
+  $scl_name      = $cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/cql_type.pp
+++ b/manifests/schema/cql_type.pp
@@ -20,21 +20,43 @@ define cassandra::schema::cql_type (
   $scl_name      = $::cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
+
+  if $use_scl {
+    $quote = '\"'
+  } else {
+    $quote = '"'
+  }
+
   $read_script = "DESC TYPE ${keyspace}.${cql_type_name}"
-  $read_command = "${::cassandra::schema::cqlsh_opts} -e \"${read_script}\" ${::cassandra::schema::cqlsh_conn}"
+  $read_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${read_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+  if $use_scl {
+    $read_command = "/usr/bin/scl enable ${scl_name} \"${read_command_tmp}\""
+  } else {
+    $read_command = $read_command_tmp
+  }
 
   if $ensure == present {
     $create_script1 = "CREATE TYPE IF NOT EXISTS ${keyspace}.${cql_type_name}"
     $create_script2 = join(join_keys_to_values($fields, ' '), ', ')
     $create_script = "${create_script1} (${create_script2})"
-    $create_command = "${::cassandra::schema::cqlsh_opts} -e \"${create_script}\" ${::cassandra::schema::cqlsh_conn}"
+    $create_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${create_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+    if $use_scl {
+      $create_command = "/usr/bin/scl enable ${scl_name} \"${create_command_tmp}\""
+    } else {
+      $create_command = $create_command_tmp
+    }
     exec { $create_command:
       unless  => $read_command,
       require => Exec['::cassandra::schema connection test'],
     }
   } elsif $ensure == absent {
     $delete_script = "DROP type ${keyspace}.${cql_type_name}"
-    $delete_command = "${::cassandra::schema::cqlsh_opts} -e \"${delete_script}\" ${::cassandra::schema::cqlsh_conn}"
+    $delete_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${delete_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+    if $use_scl {
+      $delete_command = "/usr/bin/scl enable ${scl_name} \"${delete_command_tmp}\""
+    } else {
+      $delete_command = $delete_command_tmp
+    }
     exec { $delete_command:
       onlyif  => $read_command,
       require => Exec['::cassandra::schema connection test'],

--- a/manifests/schema/index.pp
+++ b/manifests/schema/index.pp
@@ -17,6 +17,8 @@ define cassandra::schema::index(
   $index      = $title,
   $keys       = undef,
   $options    = undef,
+  $use_scl    = $::cassandra::params::use_scl,
+  $scl_name   = $::cassandra::params::scl_name,
   ) {
   include 'cassandra::schema'
 

--- a/manifests/schema/index.pp
+++ b/manifests/schema/index.pp
@@ -17,8 +17,8 @@ define cassandra::schema::index(
   $index      = $title,
   $keys       = undef,
   $options    = undef,
-  $use_scl    = $cassandra::params::use_scl,
-  $scl_name   = $cassandra::params::scl_name,
+  Boolean $use_scl = $cassandra::params::use_scl,
+  String[1] $scl_name = $cassandra::params::scl_name,
   ) {
   include 'cassandra::schema'
 

--- a/manifests/schema/index.pp
+++ b/manifests/schema/index.pp
@@ -22,13 +22,24 @@ define cassandra::schema::index(
   ) {
   include 'cassandra::schema'
 
+  if $use_scl {
+    $quote = '\"'
+  } else {
+    $quote = '"'
+  }
+
   # Fully qualified index name.
   $fqin = "${keyspace}.${index}"
   # Fully qualified table name.
   $fqtn = "${keyspace}.${table}"
 
   $read_script = "DESC INDEX ${fqin}"
-  $read_command = "${::cassandra::schema::cqlsh_opts} -e \"${read_script}\" ${::cassandra::schema::cqlsh_conn}"
+  $read_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${read_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+  if $use_scl {
+    $read_command = "/usr/bin/scl enable ${scl_name} \"${read_command_tmp}\""
+  } else {
+    $read_command = $read_command_tmp
+  }
 
   if $ensure == present {
     if $class_name != undef {
@@ -49,7 +60,12 @@ define cassandra::schema::index(
       $create_script = $create_part2
     }
 
-    $create_command = "${::cassandra::schema::cqlsh_opts} -e \"${create_script}\" ${::cassandra::schema::cqlsh_conn}"
+    $create_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${create_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+    if $use_scl {
+      $create_command = "/usr/bin/scl enable ${scl_name} \"${create_command_tmp}\""
+    } else {
+      $create_command = $create_command_tmp
+    }
 
     exec { $create_command:
       unless  => $read_command,
@@ -57,7 +73,12 @@ define cassandra::schema::index(
     }
   } elsif $ensure == absent {
     $delete_script = "DROP INDEX ${fqin}"
-    $delete_command = "${::cassandra::schema::cqlsh_opts} -e \"${delete_script}\" ${::cassandra::schema::cqlsh_conn}"
+    $delete_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${delete_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+    if $use_scl {
+      $delete_command = "/usr/bin/scl enable ${scl_name} \"${delete_command_tmp}\""
+    } else {
+      $delete_command = $delete_command_tmp
+    }
     exec { $delete_command:
       onlyif  => $read_command,
       require => Exec['::cassandra::schema connection test'],

--- a/manifests/schema/index.pp
+++ b/manifests/schema/index.pp
@@ -17,8 +17,8 @@ define cassandra::schema::index(
   $index      = $title,
   $keys       = undef,
   $options    = undef,
-  $use_scl    = $::cassandra::params::use_scl,
-  $scl_name   = $::cassandra::params::scl_name,
+  $use_scl    = $cassandra::params::use_scl,
+  $scl_name   = $cassandra::params::scl_name,
   ) {
   include 'cassandra::schema'
 

--- a/manifests/schema/keyspace.pp
+++ b/manifests/schema/keyspace.pp
@@ -26,6 +26,8 @@ define cassandra::schema::keyspace(
   $durable_writes  = true,
   $keyspace_name   = $title,
   $replication_map = {},
+  $use_scl         = $::cassandra::params::use_scl,
+  $scl_name        = $::cassandra::params::scl_name,
   ) {
   include 'cassandra::schema'
 

--- a/manifests/schema/keyspace.pp
+++ b/manifests/schema/keyspace.pp
@@ -26,8 +26,8 @@ define cassandra::schema::keyspace(
   $durable_writes  = true,
   $keyspace_name   = $title,
   $replication_map = {},
-  $use_scl         = $cassandra::params::use_scl,
-  $scl_name        = $cassandra::params::scl_name,
+  Boolean $use_scl = $cassandra::params::use_scl,
+  String[1] $scl_name = $cassandra::params::scl_name,
   ) {
   include 'cassandra::schema'
 

--- a/manifests/schema/keyspace.pp
+++ b/manifests/schema/keyspace.pp
@@ -26,8 +26,8 @@ define cassandra::schema::keyspace(
   $durable_writes  = true,
   $keyspace_name   = $title,
   $replication_map = {},
-  $use_scl         = $::cassandra::params::use_scl,
-  $scl_name        = $::cassandra::params::scl_name,
+  $use_scl         = $cassandra::params::use_scl,
+  $scl_name        = $cassandra::params::scl_name,
   ) {
   include 'cassandra::schema'
 

--- a/manifests/schema/permission.pp
+++ b/manifests/schema/permission.pp
@@ -33,8 +33,8 @@ define cassandra::schema::permission (
   $keyspace_name    = 'ALL',
   $permission_name  = 'ALL',
   $table_name       = undef,
-  $use_scl          = $::cassandra::params::use_scl,
-  $scl_name         = $::cassandra::params::scl_name,
+  $use_scl          = $cassandra::params::use_scl,
+  $scl_name         = $cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/permission.pp
+++ b/manifests/schema/permission.pp
@@ -33,8 +33,8 @@ define cassandra::schema::permission (
   $keyspace_name    = 'ALL',
   $permission_name  = 'ALL',
   $table_name       = undef,
-  $use_scl          = $cassandra::params::use_scl,
-  $scl_name         = $cassandra::params::scl_name,
+  Boolean $use_scl = $cassandra::params::use_scl,
+  String[1] $scl_name = $cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/permission.pp
+++ b/manifests/schema/permission.pp
@@ -33,6 +33,8 @@ define cassandra::schema::permission (
   $keyspace_name    = 'ALL',
   $permission_name  = 'ALL',
   $table_name       = undef,
+  $use_scl          = $::cassandra::params::use_scl,
+  $scl_name         = $::cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/table.pp
+++ b/manifests/schema/table.pp
@@ -22,6 +22,8 @@ define cassandra::schema::table (
   $columns = {},
   $options = [],
   $table   = $title,
+  $use_scl  = $::cassandra::params::use_scl,
+  $scl_name = $::cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
   $read_script = "DESC TABLE ${keyspace}.${table}"

--- a/manifests/schema/table.pp
+++ b/manifests/schema/table.pp
@@ -26,8 +26,20 @@ define cassandra::schema::table (
   $scl_name = $::cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
+
+  if $use_scl {
+    $quote = '\"'
+  } else {
+    $quote = '"'
+  }
+
   $read_script = "DESC TABLE ${keyspace}.${table}"
-  $read_command = "${::cassandra::schema::cqlsh_opts} -e \"${read_script}\" ${::cassandra::schema::cqlsh_conn}"
+  $read_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${read_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+  if $use_scl {
+    $read_command = "/usr/bin/scl enable ${scl_name} \"${read_command_tmp}\""
+  } else {
+    $read_command = $read_command_tmp
+  }
 
   if $ensure == present {
     $create_script1 = "CREATE TABLE IF NOT EXISTS ${keyspace}.${table}"
@@ -41,14 +53,24 @@ define cassandra::schema::table (
       $create_script = "${create_script1} (${cols_def_rm_collection_type})"
     }
 
-    $create_command = "${::cassandra::schema::cqlsh_opts} -e \"${create_script}\" ${::cassandra::schema::cqlsh_conn}"
+    $create_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${create_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+    if $use_scl {
+      $create_command = "/usr/bin/scl enable ${scl_name} \"${create_command_tmp}\""
+    } else {
+      $create_command = $create_command_tmp
+    }
     exec { $create_command:
       unless  => $read_command,
       require => Exec['::cassandra::schema connection test'],
     }
   } elsif $ensure == absent {
     $delete_script = "DROP TABLE IF EXISTS ${keyspace}.${table}"
-    $delete_command = "${::cassandra::schema::cqlsh_opts} -e \"${delete_script}\" ${::cassandra::schema::cqlsh_conn}"
+    $delete_command_tmp = "${::cassandra::schema::cqlsh_opts} -e ${quote}${delete_script}${quote} ${::cassandra::schema::cqlsh_conn}"
+    if $use_scl {
+      $delete_command = "/usr/bin/scl enable ${scl_name} \"${delete_command_tmp}\""
+    } else {
+      $delete_command = $delete_command_tmp
+    }
     exec { $delete_command:
       onlyif  => $read_command,
       require => Exec['::cassandra::schema connection test'],

--- a/manifests/schema/table.pp
+++ b/manifests/schema/table.pp
@@ -22,8 +22,8 @@ define cassandra::schema::table (
   $columns = {},
   $options = [],
   $table   = $title,
-  $use_scl  = $cassandra::params::use_scl,
-  $scl_name = $cassandra::params::scl_name,
+  Boolean $use_scl = $cassandra::params::use_scl,
+  String[1] $scl_name = $cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/table.pp
+++ b/manifests/schema/table.pp
@@ -22,8 +22,8 @@ define cassandra::schema::table (
   $columns = {},
   $options = [],
   $table   = $title,
-  $use_scl  = $::cassandra::params::use_scl,
-  $scl_name = $::cassandra::params::scl_name,
+  $use_scl  = $cassandra::params::use_scl,
+  $scl_name = $cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/user.pp
+++ b/manifests/schema/user.pp
@@ -22,6 +22,8 @@ define cassandra::schema::user (
   $password  = undef,
   $superuser = false,
   $user_name = $title,
+  $use_scl   = $::cassandra::params::use_scl,
+  $scl_name  = $::cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/user.pp
+++ b/manifests/schema/user.pp
@@ -22,8 +22,8 @@ define cassandra::schema::user (
   $password  = undef,
   $superuser = false,
   $user_name = $title,
-  $use_scl   = $::cassandra::params::use_scl,
-  $scl_name  = $::cassandra::params::scl_name,
+  $use_scl   = $cassandra::params::use_scl,
+  $scl_name  = $cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/manifests/schema/user.pp
+++ b/manifests/schema/user.pp
@@ -22,8 +22,8 @@ define cassandra::schema::user (
   $password  = undef,
   $superuser = false,
   $user_name = $title,
-  $use_scl   = $cassandra::params::use_scl,
-  $scl_name  = $cassandra::params::scl_name,
+  Boolean $use_scl = $cassandra::params::use_scl,
+  String[1] $scl_name = $cassandra::params::scl_name,
   ){
   include 'cassandra::schema'
 

--- a/spec/classes/schema_spec.rb
+++ b/spec/classes/schema_spec.rb
@@ -63,8 +63,7 @@ describe 'cassandra::schema' do
                   returns: 0,
                   tries: 6,
                   try_sleep: 30,
-                  unless: read_command,
-                  require: 'Exec[test testscl SCL]')
+                  unless: read_command)
     end
   end
 

--- a/spec/classes/schema_spec.rb
+++ b/spec/classes/schema_spec.rb
@@ -30,6 +30,44 @@ describe 'cassandra::schema' do
     end
   end
 
+  context 'Ensure that a connection test is made with SCL.' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let :params do
+      {
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to contain_class('cassandra::schema').
+        with(connection_tries: 6,
+             connection_try_sleep: 30,
+             cqlsh_additional_options: '',
+             cqlsh_command: '/usr/bin/cqlsh',
+             cqlsh_host: 'localhost',
+             cqlsh_password: nil,
+             cqlsh_port: 9042,
+             cqlsh_user: 'cassandra')
+
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \'DESC KEYSPACES\' localhost 9042"'
+
+      is_expected.to contain_exec('::cassandra::schema connection test').
+        only_with(command: read_command,
+                  returns: 0,
+                  tries: 6,
+                  try_sleep: 30,
+                  unless: read_command,
+                  require: 'Exec[test testscl SCL]')
+    end
+  end
+
   context 'Test that users can specify a credentials file.' do
     let :facts do
       {

--- a/spec/classes/schema_spec.rb
+++ b/spec/classes/schema_spec.rb
@@ -42,7 +42,9 @@ describe 'cassandra::schema' do
 
     let :params do
       {
-        cqlsh_client_config: '/root/.puppetcqlshrc'
+        cqlsh_client_config: '/root/.puppetcqlshrc',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -79,7 +81,9 @@ describe 'cassandra::schema' do
     let :params do
       {
         cqlsh_client_config: '/root/.puppetcqlshrc',
-        cqlsh_password: 'topsecret'
+        cqlsh_password: 'topsecret',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 

--- a/spec/defines/schema/cql_type_spec.rb
+++ b/spec/defines/schema/cql_type_spec.rb
@@ -18,7 +18,9 @@ describe 'cassandra::schema::cql_type' do
           {
             'firstname' => 'text',
             'lastname'  => 'text'
-          }
+          },
+        'use_scl'  => false,
+        'scl_name' => 'nodefault'
       }
     end
 
@@ -42,7 +44,9 @@ describe 'cassandra::schema::cql_type' do
     let(:params) do
       {
         'ensure'   => 'absent',
-        'keyspace' => 'Excalibur'
+        'keyspace' => 'Excalibur',
+        'use_scl'  => false,
+        'scl_name' => 'nodefault'
       }
     end
 

--- a/spec/defines/schema/cql_type_spec.rb
+++ b/spec/defines/schema/cql_type_spec.rb
@@ -28,7 +28,48 @@ describe 'cassandra::schema::cql_type' do
       is_expected.to compile
       is_expected.to contain_class('cassandra::schema')
       is_expected.to contain_cassandra__schema__cql_type('fullname')
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "CREATE TYPE IF NOT EXISTS Excelsior.fullname (firstname text, lastname text)" localhost 9042')
+      read_command = '/usr/bin/cqlsh   -e "DESC TYPE Excelsior.fullname" localhost 9042'
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE TYPE IF NOT EXISTS Excelsior.fullname '
+      exec_command += '(firstname text, lastname text)" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'CQL TYPE (fullname) with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'fullname' }
+
+    let(:params) do
+      {
+        'keyspace' => 'Excelsior',
+        fields:
+          {
+            'firstname' => 'text',
+            'lastname'  => 'text'
+          },
+        'use_scl'  => true,
+        'scl_name' => 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      is_expected.to contain_class('cassandra::schema')
+      is_expected.to contain_cassandra__schema__cql_type('fullname')
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC TYPE Excelsior.fullname\" localhost 9042"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE TYPE IF NOT EXISTS Excelsior.fullname '
+      exec_command += '(firstname text, lastname text)\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -53,7 +94,40 @@ describe 'cassandra::schema::cql_type' do
     it do
       is_expected.to compile
       is_expected.to contain_cassandra__schema__cql_type('address')
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "DROP type Excalibur.address" localhost 9042')
+      read_command = '/usr/bin/cqlsh   -e "DESC TYPE Excalibur.address" localhost 9042'
+      exec_command = '/usr/bin/cqlsh   -e "DROP type Excalibur.address" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Set ensure to absent with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'address' }
+    let(:params) do
+      {
+        'ensure'   => 'absent',
+        'keyspace' => 'Excalibur',
+        'use_scl'  => true,
+        'scl_name' => 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      is_expected.to contain_cassandra__schema__cql_type('address')
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC TYPE Excalibur.address\" localhost 9042"'
+      exec_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DROP type Excalibur.address\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 

--- a/spec/defines/schema/index_spec.rb
+++ b/spec/defines/schema/index_spec.rb
@@ -15,7 +15,9 @@ describe 'cassandra::schema::index' do
       {
         keys: 'lname',
         keyspace: 'mykeyspace',
-        table: 'users'
+        table: 'users',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -41,7 +43,9 @@ describe 'cassandra::schema::index' do
         class_name: 'path.to.the.IndexClass',
         keys: 'email',
         keyspace: 'Excelsior',
-        table: 'users'
+        table: 'users',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -66,7 +70,9 @@ describe 'cassandra::schema::index' do
         keys: 'email',
         keyspace: 'Excelsior',
         options: "{'storage': '/mnt/ssd/indexes/'}",
-        table: 'users'
+        table: 'users',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -91,7 +97,9 @@ describe 'cassandra::schema::index' do
         ensure: 'absent',
         keys: 'lname',
         keyspace: 'Excelsior',
-        table: 'users'
+        table: 'users',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 

--- a/spec/defines/schema/index_spec.rb
+++ b/spec/defines/schema/index_spec.rb
@@ -24,7 +24,42 @@ describe 'cassandra::schema::index' do
     it do
       is_expected.to compile
       is_expected.to contain_cassandra__schema__index('user_index')
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "CREATE INDEX IF NOT EXISTS user_index ON mykeyspace.users (lname)" localhost 9042')
+      read_command = '/usr/bin/cqlsh   -e "DESC INDEX mykeyspace.user_index" localhost 9042'
+      exec_command = '/usr/bin/cqlsh   -e "CREATE INDEX IF NOT EXISTS user_index ON mykeyspace.users (lname)" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Create a basic index with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'user_index' }
+
+    let(:params) do
+      {
+        keys: 'lname',
+        keyspace: 'mykeyspace',
+        table: 'users',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      is_expected.to contain_cassandra__schema__index('user_index')
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC INDEX mykeyspace.user_index\" localhost 9042"'
+      exec_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE INDEX IF NOT EXISTS user_index ON mykeyspace.users (lname)\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -51,9 +86,45 @@ describe 'cassandra::schema::index' do
 
     it do
       is_expected.to compile
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "CREATE CUSTOM INDEX IF NOT EXISTS user_index ON Excelsior.users (email) USING \'path.to.the.IndexClass\'" localhost 9042')
+      read_command = '/usr/bin/cqlsh   -e "DESC INDEX Excelsior.user_index" localhost 9042'
+      exec_command = '/usr/bin/cqlsh   -e "CREATE CUSTOM INDEX IF NOT EXISTS user_index ON Excelsior.users (email) USING \'path.to.the.IndexClass\'" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
+
+  context 'Create a custom index with SCL.' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'user_index' }
+
+    let(:params) do
+      {
+        class_name: 'path.to.the.IndexClass',
+        keys: 'email',
+        keyspace: 'Excelsior',
+        table: 'users',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC INDEX Excelsior.user_index\" localhost 9042"'
+      exec_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE CUSTOM INDEX IF NOT EXISTS user_index ON Excelsior.users (email) USING \'path.to.the.IndexClass\'\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
   context 'Create a custom index with options.' do
     let :facts do
       {
@@ -78,7 +149,47 @@ describe 'cassandra::schema::index' do
 
     it do
       is_expected.to compile
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "CREATE CUSTOM INDEX IF NOT EXISTS user_index ON Excelsior.users (email) USING \'path.to.the.IndexClass\' WITH OPTIONS = {\'storage\': \'/mnt/ssd/indexes/\'}" localhost 9042')
+      read_command = '/usr/bin/cqlsh   -e "DESC INDEX Excelsior.user_index" localhost 9042'
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE CUSTOM INDEX IF NOT EXISTS user_index ON '
+      exec_command += 'Excelsior.users (email) USING \'path.to.the.IndexClass\' WITH OPTIONS = {'
+      exec_command += '\'storage\': \'/mnt/ssd/indexes/\'}" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Create a custom index with options with SCL.' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'user_index' }
+
+    let(:params) do
+      {
+        class_name: 'path.to.the.IndexClass',
+        keys: 'email',
+        keyspace: 'Excelsior',
+        options: "{'storage': '/mnt/ssd/indexes/'}",
+        table: 'users',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC INDEX Excelsior.user_index\" localhost 9042"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE CUSTOM INDEX IF NOT EXISTS user_index ON '
+      exec_command += 'Excelsior.users (email) USING \'path.to.the.IndexClass\' WITH OPTIONS = {'
+      exec_command += '\'storage\': \'/mnt/ssd/indexes/\'}\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -105,7 +216,42 @@ describe 'cassandra::schema::index' do
 
     it do
       is_expected.to compile
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "DROP INDEX Excelsior.user_index" localhost 9042')
+      read_command = '/usr/bin/cqlsh   -e "DESC INDEX Excelsior.user_index" localhost 9042'
+      exec_command = '/usr/bin/cqlsh   -e "DROP INDEX Excelsior.user_index" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Drop Index with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'user_index' }
+
+    let(:params) do
+      {
+        ensure: 'absent',
+        keys: 'lname',
+        keyspace: 'Excelsior',
+        table: 'users',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC INDEX Excelsior.user_index\" localhost 9042"'
+      exec_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DROP INDEX Excelsior.user_index\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 

--- a/spec/defines/schema/keyspace_spec.rb
+++ b/spec/defines/schema/keyspace_spec.rb
@@ -27,7 +27,48 @@ describe 'cassandra::schema::keyspace' do
     it do
       is_expected.to compile
       is_expected.to contain_class('cassandra::schema')
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "CREATE KEYSPACE IF NOT EXISTS foobar WITH REPLICATION = { \'class\' : \'SimpleStrategy\', \'replication_factor\' : 3 } AND DURABLE_WRITES = true" localhost 9042')
+      read_command =  '/usr/bin/cqlsh   -e "DESC KEYSPACE foobar" localhost 9042'
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE KEYSPACE IF NOT EXISTS foobar WITH REPLICATION = '
+      exec_command += '{ \'class\' : \'SimpleStrategy\', \'replication_factor\' : 3 } '
+      exec_command += 'AND DURABLE_WRITES = true" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Set ensure to present (SimpleStrategy) with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'foobar' }
+
+    let(:params) do
+      {
+        ensure: 'present',
+        replication_map:
+          {
+            'keyspace_class'     => 'SimpleStrategy',
+            'replication_factor' => 3
+          },
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      read_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC KEYSPACE foobar\" localhost 9042"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE KEYSPACE IF NOT EXISTS foobar WITH REPLICATION = '
+      exec_command += '{ \'class\' : \'SimpleStrategy\', \'replication_factor\' : 3 } '
+      exec_command += 'AND DURABLE_WRITES = true\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -57,7 +98,49 @@ describe 'cassandra::schema::keyspace' do
 
     it do
       is_expected.to contain_cassandra__schema__keyspace('foobar')
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "CREATE KEYSPACE IF NOT EXISTS foobar WITH REPLICATION = { \'class\' : \'NetworkTopologyStrategy\', \'dc1\': 3, \'dc2\': 2 } AND DURABLE_WRITES = true" localhost 9042')
+      read_command =  '/usr/bin/cqlsh   -e "DESC KEYSPACE foobar" localhost 9042'
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE KEYSPACE IF NOT EXISTS foobar WITH REPLICATION = '
+      exec_command += '{ \'class\' : \'NetworkTopologyStrategy\', \'dc1\': 3, \'dc2\': 2 } '
+      exec_command += 'AND DURABLE_WRITES = true" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Set ensure to present (NetworkTopologyStrategy) with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'foobar' }
+
+    let(:params) do
+      {
+        ensure: 'present',
+        replication_map:
+          {
+            'keyspace_class' => 'NetworkTopologyStrategy',
+            'dc1'            => '3',
+            'dc2'            => '2'
+          },
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to contain_cassandra__schema__keyspace('foobar')
+      read_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC KEYSPACE foobar\" localhost 9042"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE KEYSPACE IF NOT EXISTS foobar WITH REPLICATION = '
+      exec_command += '{ \'class\' : \'NetworkTopologyStrategy\', \'dc1\': 3, \'dc2\': 2 } '
+      exec_command += 'AND DURABLE_WRITES = true\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -80,7 +163,38 @@ describe 'cassandra::schema::keyspace' do
 
     it do
       is_expected.to compile
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "DROP KEYSPACE foobar" localhost 9042')
+      read_command = '/usr/bin/cqlsh   -e "DESC KEYSPACE foobar" localhost 9042'
+      exec_command = '/usr/bin/cqlsh   -e "DROP KEYSPACE foobar" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Set ensure to absent with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'foobar' }
+    let(:params) do
+      {
+        ensure: 'absent',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC KEYSPACE foobar\" localhost 9042"'
+      exec_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DROP KEYSPACE foobar\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 

--- a/spec/defines/schema/keyspace_spec.rb
+++ b/spec/defines/schema/keyspace_spec.rb
@@ -18,7 +18,9 @@ describe 'cassandra::schema::keyspace' do
           {
             'keyspace_class'     => 'SimpleStrategy',
             'replication_factor' => 3
-          }
+          },
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -47,7 +49,9 @@ describe 'cassandra::schema::keyspace' do
             'keyspace_class' => 'NetworkTopologyStrategy',
             'dc1'            => '3',
             'dc2'            => '2'
-          }
+          },
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -68,7 +72,9 @@ describe 'cassandra::schema::keyspace' do
     let(:title) { 'foobar' }
     let(:params) do
       {
-        ensure: 'absent'
+        ensure: 'absent',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 

--- a/spec/defines/schema/permission_spec.rb
+++ b/spec/defines/schema/permission_spec.rb
@@ -68,6 +68,36 @@ describe 'cassandra::schema::permission' do
                   require: 'Exec[::cassandra::schema connection test]')
     end
   end
+
+  context 'spillman:SELECT:ALL with SCL' do
+    let(:title) { 'spillman:SELECT:ALL' }
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:params) do
+      {
+        user_name: 'spillman',
+        permission_name: 'SELECT',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to have_resource_count(9)
+      is_expected.to contain_cassandra__schema__permission('spillman:SELECT:ALL')
+      read_script =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST ALL PERMISSIONS ON ALL KEYSPACES\" '
+      read_script += 'localhost 9042 | grep \' spillman | *spillman | .* SELECT$\'"'
+      script_command = 'GRANT SELECT ON ALL KEYSPACES TO spillman'
+      exec_command = "/usr/bin/scl enable testscl \"/usr/bin/cqlsh   -e \\\"#{script_command}\\\" localhost 9042\""
+      is_expected.to contain_exec(script_command).
+        only_with(command: exec_command,
+                  unless: read_script,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -103,6 +133,37 @@ describe 'cassandra::schema::permission' do
                   require: 'Exec[::cassandra::schema connection test]')
     end
   end
+
+  context 'akers:modify:field with SCL' do
+    let(:title) { 'akers:modify:field' }
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:params) do
+      {
+        user_name: 'akers',
+        keyspace_name: 'field',
+        permission_name: 'MODIFY',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to have_resource_count(9)
+      is_expected.to contain_cassandra__schema__permission('akers:modify:field')
+      read_script =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST ALL PERMISSIONS ON KEYSPACE field\" '
+      read_script += 'localhost 9042 | grep \' akers | *akers | .* MODIFY$\'"'
+      script_command = 'GRANT MODIFY ON KEYSPACE field TO akers'
+      exec_command = "/usr/bin/scl enable testscl \"/usr/bin/cqlsh   -e \\\"#{script_command}\\\" localhost 9042\""
+      is_expected.to contain_exec(script_command).
+        only_with(command: exec_command,
+                  unless: read_script,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -139,6 +200,39 @@ describe 'cassandra::schema::permission' do
     end
   end
 
+  context 'boone:alter:forty9ers with SCL' do
+    let(:title) { 'boone:alter:forty9ers' }
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:params) do
+      {
+        user_name: 'boone',
+        keyspace_name: 'forty9ers',
+        permission_name: 'ALTER',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to have_resource_count(9)
+      is_expected.to contain_cassandra__schema__permission('boone:alter:forty9ers')
+      read_script =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST ALL PERMISSIONS ON KEYSPACE forty9ers\" '
+      read_script += 'localhost 9042 | grep \' boone | *boone | .* ALTER$\'"'
+      script_command = 'GRANT ALTER ON KEYSPACE forty9ers TO boone'
+      exec_command = "/usr/bin/scl enable testscl \"/usr/bin/cqlsh   -e \\\"#{script_command}\\\" localhost 9042\""
+      is_expected.to contain_exec(script_command).
+        only_with(command: exec_command,
+                  unless: read_script,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
   context 'boone:ALL:ravens.plays' do
     let(:title) { 'boone:ALL:ravens.plays' }
     let :facts do
@@ -163,7 +257,7 @@ describe 'cassandra::schema::permission' do
       is_expected.to contain_cassandra__schema__permission('boone:ALL:ravens.plays')
     end
 
-    expected_values = %w{ALTER AUTHORIZE DROP MODIFY SELECT}
+    expected_values = %w[ALTER AUTHORIZE DROP MODIFY SELECT]
     expected_values.each do |val|
       it do
         is_expected.to contain_cassandra__schema__permission("boone:ALL:ravens.plays - #{val}").with(
@@ -211,7 +305,7 @@ describe 'cassandra::schema::permission' do
       is_expected.to contain_cassandra__schema__permission('boone:ALL:ravens.plays')
     end
 
-    expected_values = %w{ALTER AUTHORIZE DROP MODIFY SELECT}
+    expected_values = %w[ALTER AUTHORIZE DROP MODIFY SELECT]
     expected_values.each do |val|
       it do
         is_expected.to contain_cassandra__schema__permission("boone:ALL:ravens.plays - #{val}").with(
@@ -268,6 +362,38 @@ describe 'cassandra::schema::permission' do
                   require: 'Exec[::cassandra::schema connection test]')
     end
   end
+
+  context 'REVOKE boone:SELECT:ravens.plays with SCL' do
+    let(:title) { 'REVOKE boone:SELECT:ravens.plays' }
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:params) do
+      {
+        ensure: 'absent',
+        user_name: 'boone',
+        keyspace_name: 'forty9ers',
+        permission_name: 'SELECT',
+        use_scl: true,
+        scl_name: 'testscl'
+      }
+    end
+
+    it do
+      is_expected.to have_resource_count(9)
+      is_expected.to contain_cassandra__schema__permission('REVOKE boone:SELECT:ravens.plays')
+      read_script =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST ALL PERMISSIONS ON KEYSPACE forty9ers\" '
+      read_script += "localhost 9042 | grep ' boone | *boone | .* SELECT$'\""
+      script_command = 'REVOKE SELECT ON KEYSPACE forty9ers FROM boone'
+      exec_command = "/usr/bin/scl enable testscl \"/usr/bin/cqlsh   -e \\\"#{script_command}\\\" localhost 9042\""
+      is_expected.to contain_exec(script_command).
+        only_with(command: exec_command,
+                  onlyif: read_script,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 end

--- a/spec/defines/schema/permission_spec.rb
+++ b/spec/defines/schema/permission_spec.rb
@@ -49,7 +49,9 @@ describe 'cassandra::schema::permission' do
     let(:params) do
       {
         user_name: 'spillman',
-        permission_name: 'SELECT'
+        permission_name: 'SELECT',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -73,7 +75,9 @@ describe 'cassandra::schema::permission' do
       {
         user_name: 'akers',
         keyspace_name: 'field',
-        permission_name: 'MODIFY'
+        permission_name: 'MODIFY',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -97,7 +101,9 @@ describe 'cassandra::schema::permission' do
       {
         user_name: 'boone',
         keyspace_name: 'forty9ers',
-        permission_name: 'ALTER'
+        permission_name: 'ALTER',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -121,7 +127,9 @@ describe 'cassandra::schema::permission' do
       {
         user_name: 'boone',
         keyspace_name: 'ravens',
-        table_name: 'plays'
+        table_name: 'plays',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 
@@ -161,7 +169,9 @@ describe 'cassandra::schema::permission' do
         ensure: 'absent',
         user_name: 'boone',
         keyspace_name: 'forty9ers',
-        permission_name: 'SELECT'
+        permission_name: 'SELECT',
+        use_scl: false,
+        scl_name: 'nodefault'
       }
     end
 

--- a/spec/defines/schema/table_spec.rb
+++ b/spec/defines/schema/table_spec.rb
@@ -13,6 +13,8 @@ describe 'cassandra::schema::table' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         keyspace: 'Excelsior',
         columns:
           {
@@ -51,6 +53,8 @@ describe 'cassandra::schema::table' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         keyspace: 'Excelsior',
         ensure: 'absent'
       }

--- a/spec/defines/schema/table_spec.rb
+++ b/spec/defines/schema/table_spec.rb
@@ -37,7 +37,61 @@ describe 'cassandra::schema::table' do
     it do
       is_expected.to compile
       is_expected.to contain_cassandra__schema__table('users')
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "CREATE TABLE IF NOT EXISTS Excelsior.users (userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, todo map<timestamp, text>, tuple<int, text,text>, PRIMARY KEY (userid)) WITH COMPACT STORAGE AND ID=\'5a1c395e-b41f-11e5-9f22-ba0be0483c18\'" localhost 9042')
+      read_command =  '/usr/bin/cqlsh   -e "DESC TABLE Excelsior.users" localhost 9042'
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE TABLE IF NOT EXISTS Excelsior.users '
+      exec_command += '(userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, '
+      exec_command += 'todo map<timestamp, text>, tuple<int, text,text>, PRIMARY KEY (userid)) '
+      exec_command += 'WITH COMPACT STORAGE AND ID=\'5a1c395e-b41f-11e5-9f22-ba0be0483c18\'" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Create Table with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'users' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        keyspace: 'Excelsior',
+        columns:
+          {
+            'userid' => 'text',
+            'username' => 'FROZEN<fullname>',
+            'emails' => 'set<text>',
+            'top_scores' => 'list<int>',
+            'todo' => 'map<timestamp, text>',
+            'COLLECTION-TYPE' => 'tuple<int, text,text>',
+            'PRIMARY KEY' => '(userid)'
+          },
+        options:
+          [
+            'COMPACT STORAGE',
+            'ID=\'5a1c395e-b41f-11e5-9f22-ba0be0483c18\''
+          ]
+      }
+    end
+
+    it do
+      is_expected.to compile
+      is_expected.to contain_cassandra__schema__table('users')
+      read_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC TABLE Excelsior.users\" localhost 9042"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE TABLE IF NOT EXISTS Excelsior.users '
+      exec_command += '(userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, '
+      exec_command += 'todo map<timestamp, text>, tuple<int, text,text>, PRIMARY KEY (userid)) '
+      exec_command += 'WITH COMPACT STORAGE AND ID=\'5a1c395e-b41f-11e5-9f22-ba0be0483c18\'\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -62,7 +116,40 @@ describe 'cassandra::schema::table' do
 
     it do
       is_expected.to compile
-      is_expected.to contain_exec('/usr/bin/cqlsh   -e "DROP TABLE IF EXISTS Excelsior.users" localhost 9042')
+      read_command = '/usr/bin/cqlsh   -e "DESC TABLE Excelsior.users" localhost 9042'
+      exec_command = '/usr/bin/cqlsh   -e "DROP TABLE IF EXISTS Excelsior.users" localhost 9042'
+      is_expected.to contain_exec(exec_command).
+        only_with(onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Drop Table with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat'
+      }
+    end
+
+    let(:title) { 'users' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        keyspace: 'Excelsior',
+        ensure: 'absent'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DESC TABLE Excelsior.users\" localhost 9042"'
+      exec_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DROP TABLE IF EXISTS Excelsior.users\" localhost 9042"'
+      is_expected.to contain_exec(exec_command).
+        only_with(onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 

--- a/spec/defines/schema/user_spec.rb
+++ b/spec/defines/schema/user_spec.rb
@@ -14,6 +14,8 @@ describe 'cassandra::schema::user' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         password: 'Niner2',
         superuser: true
       }
@@ -40,6 +42,8 @@ describe 'cassandra::schema::user' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         password: 'Niner2',
         superuser: true
       }
@@ -66,6 +70,8 @@ describe 'cassandra::schema::user' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         password: 'Niner2'
       }
     end
@@ -91,6 +97,8 @@ describe 'cassandra::schema::user' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         password: 'Niner2',
         superuser: true
       }
@@ -117,6 +125,8 @@ describe 'cassandra::schema::user' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         password: 'kaZe89a',
         login: false
       }
@@ -143,6 +153,8 @@ describe 'cassandra::schema::user' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         password: 'Niner2',
         ensure: 'absent'
       }
@@ -168,6 +180,8 @@ describe 'cassandra::schema::user' do
 
     let(:params) do
       {
+        use_scl: false,
+        scl_name: 'nodefault',
         password: 'Niner2',
         ensure: 'absent'
       }

--- a/spec/defines/schema/user_spec.rb
+++ b/spec/defines/schema/user_spec.rb
@@ -23,9 +23,45 @@ describe 'cassandra::schema::user' do
 
     it do
       is_expected.to contain_cassandra__schema__user('akers').with_ensure('present')
-      is_expected.to contain_exec('Create user (akers)').with(
-        command: '/usr/bin/cqlsh   -e "CREATE USER IF NOT EXISTS akers WITH PASSWORD \'Niner2\' SUPERUSER" localhost 9042'
-      )
+      read_command = '/usr/bin/cqlsh   -e "LIST USERS" localhost 9042 | grep \'\s*akers |\''
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE USER IF NOT EXISTS akers'
+      exec_command += ' WITH PASSWORD \'Niner2\' SUPERUSER" localhost 9042'
+      is_expected.to contain_exec('Create user (akers)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Create a supper user on cassandrarelease undef with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: nil
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        password: 'Niner2',
+        superuser: true
+      }
+    end
+
+    it do
+      is_expected.to contain_cassandra__schema__user('akers').with_ensure('present')
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST USERS\" localhost 9042 | grep \'\s*akers |\'"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE USER IF NOT EXISTS akers'
+      exec_command += ' WITH PASSWORD \'Niner2\' SUPERUSER\" localhost 9042"'
+      is_expected.to contain_exec('Create user (akers)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -51,9 +87,45 @@ describe 'cassandra::schema::user' do
 
     it do
       is_expected.to contain_cassandra__schema__user('akers').with_ensure('present')
-      is_expected.to contain_exec('Create user (akers)').with(
-        command: '/usr/bin/cqlsh   -e "CREATE USER IF NOT EXISTS akers WITH PASSWORD \'Niner2\' SUPERUSER" localhost 9042'
-      )
+      read_command = '/usr/bin/cqlsh   -e "LIST USERS" localhost 9042 | grep \'\s*akers |\''
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE USER IF NOT EXISTS akers'
+      exec_command += ' WITH PASSWORD \'Niner2\' SUPERUSER" localhost 9042'
+      is_expected.to contain_exec('Create user (akers)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Create a supper user in cassandrarelease < 2.2 with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '2.0.1'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        password: 'Niner2',
+        superuser: true
+      }
+    end
+
+    it do
+      is_expected.to contain_cassandra__schema__user('akers').with_ensure('present')
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST USERS\" localhost 9042 | grep \'\s*akers |\'"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE USER IF NOT EXISTS akers'
+      exec_command += ' WITH PASSWORD \'Niner2\' SUPERUSER\" localhost 9042"'
+      is_expected.to contain_exec('Create user (akers)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -78,9 +150,44 @@ describe 'cassandra::schema::user' do
 
     it do
       is_expected.to contain_cassandra__schema__user('akers').with_ensure('present')
-      is_expected.to contain_exec('Create user (akers)').with(
-        command: '/usr/bin/cqlsh   -e "CREATE USER IF NOT EXISTS akers WITH PASSWORD \'Niner2\' NOSUPERUSER" localhost 9042'
-      )
+      read_command = '/usr/bin/cqlsh   -e "LIST USERS" localhost 9042 | grep \'\s*akers |\''
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE USER IF NOT EXISTS akers'
+      exec_command += ' WITH PASSWORD \'Niner2\' NOSUPERUSER" localhost 9042'
+      is_expected.to contain_exec('Create user (akers)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Create a user in cassandrarelease < 2.2 with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '2.0.1'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        password: 'Niner2'
+      }
+    end
+
+    it do
+      is_expected.to contain_cassandra__schema__user('akers').with_ensure('present')
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST USERS\" localhost 9042 | grep \'\s*akers |\'"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE USER IF NOT EXISTS akers'
+      exec_command += ' WITH PASSWORD \'Niner2\' NOSUPERUSER\" localhost 9042"'
+      is_expected.to contain_exec('Create user (akers)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -106,9 +213,45 @@ describe 'cassandra::schema::user' do
 
     it do
       is_expected.to contain_cassandra__schema__user('akers').with_ensure('present')
-      is_expected.to contain_exec('Create user (akers)').with(
-        command: '/usr/bin/cqlsh   -e "CREATE ROLE IF NOT EXISTS akers WITH PASSWORD = \'Niner2\' AND SUPERUSER = true AND LOGIN = true" localhost 9042'
-      )
+      read_command = '/usr/bin/cqlsh   -e "LIST ROLES" localhost 9042 | grep \'\s*akers |\''
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE ROLE IF NOT EXISTS akers'
+      exec_command += ' WITH PASSWORD = \'Niner2\' AND SUPERUSER = true AND LOGIN = true" localhost 9042'
+      is_expected.to contain_exec('Create user (akers)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Create a supper user with login in cassandrarelease > 2.2 with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '3.0.9'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        password: 'Niner2',
+        superuser: true
+      }
+    end
+
+    it do
+      is_expected.to contain_cassandra__schema__user('akers').with_ensure('present')
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST ROLES\" localhost 9042 | grep \'\s*akers |\'"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE ROLE IF NOT EXISTS akers'
+      exec_command += ' WITH PASSWORD = \'Niner2\' AND SUPERUSER = true AND LOGIN = true\" localhost 9042"'
+      is_expected.to contain_exec('Create user (akers)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -134,9 +277,45 @@ describe 'cassandra::schema::user' do
 
     it do
       is_expected.to contain_cassandra__schema__user('bob').with_ensure('present')
-      is_expected.to contain_exec('Create user (bob)').with(
-        command: '/usr/bin/cqlsh   -e "CREATE ROLE IF NOT EXISTS bob WITH PASSWORD = \'kaZe89a\'" localhost 9042'
-      )
+      read_command = '/usr/bin/cqlsh   -e "LIST ROLES" localhost 9042 | grep \'\s*bob |\''
+      exec_command =  '/usr/bin/cqlsh   -e "CREATE ROLE IF NOT EXISTS bob'
+      exec_command += ' WITH PASSWORD = \'kaZe89a\'" localhost 9042'
+      is_expected.to contain_exec('Create user (bob)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Create a user without login in cassandrarelease > 2.2 with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '3.0.9'
+      }
+    end
+
+    let(:title) { 'bob' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        password: 'kaZe89a',
+        login: false
+      }
+    end
+
+    it do
+      is_expected.to contain_cassandra__schema__user('bob').with_ensure('present')
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST ROLES\" localhost 9042 | grep \'\s*bob |\'"'
+      exec_command =  '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"CREATE ROLE IF NOT EXISTS bob'
+      exec_command += ' WITH PASSWORD = \'kaZe89a\'\" localhost 9042"'
+      is_expected.to contain_exec('Create user (bob)').
+        only_with(command: exec_command,
+                  unless: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -161,9 +340,42 @@ describe 'cassandra::schema::user' do
     end
 
     it do
-      is_expected.to contain_exec('Delete user (akers)').with(
-        command: '/usr/bin/cqlsh   -e "DROP ROLE akers" localhost 9042'
-      )
+      read_command = '/usr/bin/cqlsh   -e "LIST ROLES" localhost 9042 | grep \'\s*akers |\''
+      exec_command = '/usr/bin/cqlsh   -e "DROP ROLE akers" localhost 9042'
+      is_expected.to contain_exec('Delete user (akers)').
+        only_with(command: exec_command,
+                  onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Drop a user in cassandrarelease > 2.2 with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '3.0.9'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        password: 'Niner2',
+        ensure: 'absent'
+      }
+    end
+
+    it do
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST ROLES\" localhost 9042 | grep \'\s*akers |\'"'
+      exec_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DROP ROLE akers\" localhost 9042"'
+      is_expected.to contain_exec('Delete user (akers)').
+        only_with(command: exec_command,
+                  onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 
@@ -188,9 +400,42 @@ describe 'cassandra::schema::user' do
     end
 
     it do
-      is_expected.to contain_exec('Delete user (akers)').with(
-        command: '/usr/bin/cqlsh   -e "DROP USER akers" localhost 9042'
-      )
+      read_command = '/usr/bin/cqlsh   -e "LIST USERS" localhost 9042 | grep \'\s*akers |\''
+      exec_command = '/usr/bin/cqlsh   -e "DROP USER akers" localhost 9042'
+      is_expected.to contain_exec('Delete user (akers)').
+        only_with(command: exec_command,
+                  onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
+    end
+  end
+
+  context 'Drop a user in cassandrarelease < 2.2 with SCL' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '2.0.2'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        use_scl: true,
+        scl_name: 'testscl',
+        password: 'Niner2',
+        ensure: 'absent'
+      }
+    end
+
+    it do
+      read_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"LIST USERS\" localhost 9042 | grep \'\s*akers |\'"'
+      exec_command = '/usr/bin/scl enable testscl "/usr/bin/cqlsh   -e \"DROP USER akers\" localhost 9042"'
+      is_expected.to contain_exec('Delete user (akers)').
+        only_with(command: exec_command,
+                  onlyif: read_command,
+                  require: 'Exec[::cassandra::schema connection test]')
     end
   end
 


### PR DESCRIPTION
#### Pull Request (PR) description

Enable running `cqlsh` via python from software collections (SCL). Useful for RHEL/CentOS 6.

#### This Pull Request (PR) fixes the following issues

N/A

#### Additional info

The commits are all separated for easier review. Documentation will be done pending approval of the code changes.