### PR TITLE
Add default SCL params to Debian family OS

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,8 @@ class cassandra::params {
       $optutils_package_name = 'cassandra-tools'
       $sysctl_file = '/etc/sysctl.d/10-cassandra.conf'
       $systemctl = '/bin/systemctl'
+      $use_scl = false
+      $scl_name = 'nodefault'
     }
     'RedHat': {
       case $facts['os']['release']['major'] {


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes puppet error: Error while evaluating a Resource Statement, Evaluation Error: Unknown variable: 'cassandra::params::use_scl'