### PR TITLE
Bugfix: Correct example of calculating MAX_HEAP_SIZE.  Fixes #459.

### DIFF
--- a/examples/getting_started.pp
+++ b/examples/getting_started.pp
@@ -147,14 +147,11 @@ class { 'cassandra::schema':
     },
   },
 }
-if ($facts['memory']['system']['total_bytes'] / (1024*1024)) < 24576.0 {
-  $max_heap_size_in_mb = floor(($facts['memory']['system']['total_bytes'] / (1024*1024)) / 2)
-} elsif ($facts['memory']['system']['total_bytes'] / (1024*1024)) < 8192.0 {
-  $max_heap_size_in_mb = floor(($facts['memory']['system']['total_bytes'] / (1024*1024)) / 4)
-} else {
-  $max_heap_size_in_mb = 8192
-}
 
+$ram_sz_mb = floor($facts['memory']['system']['total_bytes'] / (1024*1024))
+$half_of_ram = floor($ram_sz_mb / 2)
+$quarter_of_ram = floor($ram_sz_mb / 4)
+$max_heap_size_in_mb = max(min($half_of_ram, 1024), min($quarter_of_ram, 8192))
 $heap_new_size = $facts['processors']['count'] * 100
 
 cassandra::file { "Set Java/Cassandra max heap size to ${max_heap_size_in_mb}.":


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Correct example of calculating MAX_HEAP_SIZE.  The logic is taken from https://docs.datastax.com/en/cassandra-oss/3.x/cassandra/operations/opsTuneJVM.html#Determiningtheheapsize so hopefully this is a clearer implementation.

#### This Pull Request (PR) fixes the following issues
Fixes #459
