### PR TITLE
Bump puppet-firewall version to allow version 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppetlabs-firewall",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs-inifile",


### PR DESCRIPTION
#### Pull Request (PR) description

Bump puppet-firewall version to <= 2.5.0

#### This Pull Request (PR) fixes the following issues

n/a