### PR TITLE
Add support for puppetlabs/stdlib 9.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -281,7 +281,7 @@ class cassandra (
     $commitlog_directory_settings = $settings
   }
 
-  if is_array($data_file_directories) {
+  if $data_file_directories =~ Array {
     file { $data_file_directories:
       ensure  => directory,
       owner   => 'cassandra',

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 3.0.0 < 9.0.0"
+      "version_requirement": ">= 3.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Hi all, many thanks for your work on all these fantastic modules. Here's my first and modest contribution.

puppetlabs/stdlib 9.x removed deprecated method `is_array`. This PR simply replaces the call to `is_array` by built-in puppet data type comparison operator and updates stdlib supported versions.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
